### PR TITLE
Fix collection not appearing after submission without page refresh

### DIFF
--- a/frontend/src/pages/Collections.jsx
+++ b/frontend/src/pages/Collections.jsx
@@ -250,7 +250,17 @@ export default function Collections() {
         msgRef.current?.show('Collection updated', 'green')
       }
       closeModal()
-      await fetchAndRender(activeBranch, startDate, endDate)
+      let newStart = startDate
+      let newEnd = endDate
+      if (date < newStart) {
+        newStart = offsetDate(new Date(date).getTime(), -1)
+        setStartDate(newStart)
+      }
+      if (date > newEnd) {
+        newEnd = offsetDate(new Date(date).getTime(), 1)
+        setEndDate(newEnd)
+      }
+      await fetchAndRender(activeBranch, newStart, newEnd)
     } catch (e) {
       msgRef.current?.show(e.message || 'Failed to save', 'red')
     }


### PR DESCRIPTION
After a successful create or update, extend the active date filter to
include the new collection's date before calling fetchAndRender, so it
is never filtered out by a stale date range.

https://claude.ai/code/session_01FgjgvRam1XVKdL5moNHhj1